### PR TITLE
Updates README to display author names

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
-# Group 14 CEG-4110 Spring 2020 Project
+= CEG-4110 Spring 2020 Group 14 Project
+
 **Spencer Covault, Nick Hirzel, Nate Price, Brett Salyer**
 
 = x86 Bare Metal Examples


### PR DESCRIPTION
Fixes README so that author names appear.
adoc files apparently needs to have a blank line between header and text.