### PR TITLE
Adds qemu-arch-extra to pacman deps

### DIFF
--- a/deps/pacman.txt
+++ b/deps/pacman.txt
@@ -7,4 +7,5 @@ gnu-efi-libs
 make
 nasm
 qemu
+qemu-arch-extra
 xorriso


### PR DESCRIPTION
Adds `qemu-arch-extra` to the pacman deps list, needed to run programs on archlinux